### PR TITLE
pylint fixes

### DIFF
--- a/default libraries/mainboard-v04/adafruit_rfm9x.py
+++ b/default libraries/mainboard-v04/adafruit_rfm9x.py
@@ -47,7 +47,6 @@ __version__ = "1.1.7"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RFM9x.git"
 
 
-# pylint: disable=bad-whitespace
 # Internal constants:
 # Register names (FSK Mode even though we use LoRa instead, from table 85)
 _RH_RF95_REG_00_FIFO                              = const(0x00)
@@ -233,7 +232,6 @@ FS_TX_MODE   = 0b010
 TX_MODE      = 0b011
 FS_RX_MODE   = 0b100
 RX_MODE      = 0b101
-# pylint: enable=bad-whitespace
 
 
 # Disable the too many instance members warning.  Pylint has no knowledge

--- a/default libraries/mainboard-v04/bmx160.py
+++ b/default libraries/mainboard-v04/bmx160.py
@@ -1,15 +1,11 @@
 import time
-try:
-    import struct
-except ImportError:
-    import ustruct as struct
 
 from adafruit_bus_device.i2c_device import I2CDevice
 from adafruit_bus_device.spi_device import SPIDevice
 from micropython import const
-from adafruit_register.i2c_struct import Struct, UnaryStruct
+from adafruit_register.i2c_struct import Struct
 from adafruit_register.i2c_bits import ROBits, RWBits
-from adafruit_register.i2c_bit import ROBit, RWBit
+from adafruit_register.i2c_bit import ROBit
 
 # Chip ID
 BMX160_CHIP_ID = const(0xD8)
@@ -687,11 +683,11 @@ def find_nearest_valid(desired, possible_values):
     except:
         return -1
 
-def settingswarning(interp = ""):
+def settingswarning(interp=""):
     if interp != "":
-            interp = " --"  + interp + " -- "
+        interp = " --"  + interp + " -- "
     print("BMX160 error occurred during " + interp +
-         "setting change. \nSetting not successfully changed and BMX160 may be in error state.")
+          "setting change. \nSetting not successfully changed and BMX160 may be in error state.")
 
 
 def format_binary(b):

--- a/default libraries/mainboard-v04/bq25883.py
+++ b/default libraries/mainboard-v04/bq25883.py
@@ -14,47 +14,46 @@ Implementation Notes
 from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
-from adafruit_register.i2c_struct import ROUnaryStruct, UnaryStruct
 from adafruit_register.i2c_bits import ROBits, RWBits
-from adafruit_register.i2c_bit import ROBit, RWBit
+from adafruit_register.i2c_bit import RWBit
 
 
 # Registers
 _BATV_LIM       = const(0x00)
-_CHRGI_LIM      = const(0x01) 
-_VIN_LIM        = const(0x02) 
-_IIN_LIM        = const(0x03) 
-_TERM_CTRL      = const(0x04) 
-_CHRGR_CRTL1    = const(0x05) 
-_CHRGR_CRTL2    = const(0x06) 
-_CHRGR_CRTL3    = const(0x07) 
-_CHRGR_CRTL4    = const(0x08) 
-_OTG_CTRL       = const(0x09) 
-_ICO_LIM        = const(0x0A) 
-_CHRG_STAT1     = const(0x0B) 
-_CHRG_STAT2     = const(0x0C) 
-_NTC_STAT       = const(0x0D) 
+_CHRGI_LIM      = const(0x01)
+_VIN_LIM        = const(0x02)
+_IIN_LIM        = const(0x03)
+_TERM_CTRL      = const(0x04)
+_CHRGR_CRTL1    = const(0x05)
+_CHRGR_CRTL2    = const(0x06)
+_CHRGR_CRTL3    = const(0x07)
+_CHRGR_CRTL4    = const(0x08)
+_OTG_CTRL       = const(0x09)
+_ICO_LIM        = const(0x0A)
+_CHRG_STAT1     = const(0x0B)
+_CHRG_STAT2     = const(0x0C)
+_NTC_STAT       = const(0x0D)
 _FAULT_STAT     = const(0x0E)
-_CHRGR_FLAG1    = const(0x0F) 
-_CHRGR_FLAG2    = const(0x10) 
-_FAULT_FLAG     = const(0x11) 
-_CHRGR_MSK1     = const(0x12) 
-_CHRGR_MSK2     = const(0x13) 
-_FAULT_MSK      = const(0x14) 
+_CHRGR_FLAG1    = const(0x0F)
+_CHRGR_FLAG2    = const(0x10)
+_FAULT_FLAG     = const(0x11)
+_CHRGR_MSK1     = const(0x12)
+_CHRGR_MSK2     = const(0x13)
+_FAULT_MSK      = const(0x14)
 _ADC_CTRL       = const(0x15)
-_ADC_FN_CTRL    = const(0x16) 
-_IBUS_ADC1      = const(0x17) 
-_IBUS_ADC0      = const(0x18) 
-_ICHG_ADC1      = const(0x19) 
-_ICHG_ADC0      = const(0x1A) 
-_VBUS_ADC1      = const(0x1B) 
+_ADC_FN_CTRL    = const(0x16)
+_IBUS_ADC1      = const(0x17)
+_IBUS_ADC0      = const(0x18)
+_ICHG_ADC1      = const(0x19)
+_ICHG_ADC0      = const(0x1A)
+_VBUS_ADC1      = const(0x1B)
 _VBUS_ADC0      = const(0x1C)
-_VBAT_ADC1      = const(0x1D) 
-_VBAT_ADC0      = const(0x1E) 
-_VSYS_ADC1      = const(0x1F) 
-_VSYS_ADC0      = const(0x20) 
-_TS_ADC1        = const(0x21) 
-_TS_ADC0        = const(0x22) 
+_VBAT_ADC1      = const(0x1D)
+_VBAT_ADC0      = const(0x1E)
+_VSYS_ADC1      = const(0x1F)
+_VSYS_ADC0      = const(0x20)
+_TS_ADC1        = const(0x21)
+_TS_ADC0        = const(0x22)
 _TDIE_ADC1      = const(0x23)
 _TDIE_ADC0      = const(0x24)
 _PART_INFO      = const(0x25)
@@ -87,18 +86,18 @@ class BQ25883:
 
     @property
     def status(self):
-        print('Fault:',bin(self._fault_status))   
+        print('Fault:',bin(self._fault_status))
         print('Charger Status 1:',bin(self._chrgr_status1))
         print('Charger Status 2:',bin(self._chrgr_status2))
-        print('Charge Status:',bin(self._chrg_status))  
-        print('Charge Control2:',bin(self._chrg_ctrl2))  
-        print('NTC Status:',bin(self._ntc_stat))  
+        print('Charge Status:',bin(self._chrg_status))
+        print('Charge Control2:',bin(self._chrg_ctrl2))
+        print('NTC Status:',bin(self._ntc_stat))
         print('OTG:',hex(self._otg_ctrl))
 
 
     @property
     def charging(self):
-        print('Charge Control2:',bin(self._chrg_ctrl2))    
+        print('Charge Control2:',bin(self._chrg_ctrl2))
     @charging.setter
     def charging(self,value):
         assert type(value) == bool
@@ -106,7 +105,7 @@ class BQ25883:
 
     @property
     def wdt(self):
-        print('Watchdog Timer:',bin(self._wdt))    
+        print('Watchdog Timer:',bin(self._wdt))
     @wdt.setter
     def wdt(self,value):
         if not value:
@@ -116,7 +115,7 @@ class BQ25883:
 
     @property
     def led(self):
-        print('Status LED:',bin(self._stat_dis))    
+        print('Status LED:',bin(self._stat_dis))
     @led.setter
     def led(self,value):
         assert type(value) == bool

--- a/default libraries/mainboard-v04/pycubed.py
+++ b/default libraries/mainboard-v04/pycubed.py
@@ -10,7 +10,7 @@ TODO
 - 
 
 """
-import adafruit_gps
+#import adafruit_gps
 import adafruit_sdcard
 import adafruit_rfm9x
 import board, microcontroller
@@ -84,7 +84,7 @@ class Satellite:
             self.neopixel[0] = (0,0,0)
             self.hardware['Neopixel'] = True
         except Exception as e:
-            print('[WARNING][Neopixel]',e)
+            print('[WARNING][Neopixel]', e)
 
         # Initialize USB charger
         try: 
@@ -95,7 +95,7 @@ class Satellite:
             self.usb_charging=False
             self.hardware['USB'] = True
         except Exception as e:
-            print('[ERROR][USB Charger]',e)        
+            print('[ERROR][USB Charger]', e)        
 
         # Initialize sdcard
         try:
@@ -105,7 +105,7 @@ class Satellite:
             sys.path.append("/sd")
             self.hardware['SDcard'] = True
         except Exception as e:
-            print('[ERROR][SD Card]',e)
+            print('[ERROR][SD Card]', e)
         
         # Initialize Power Monitor
         try:
@@ -113,26 +113,26 @@ class Satellite:
             self.pwr.sense_resistor = 1
             self.hardware['PWR'] = True
         except Exception as e:
-            print('[ERROR][Power Monitor]',e)    
+            print('[ERROR][Power Monitor]', e)    
 
         # Initialize IMU
         try:
             self.IMU = bmx160.BMX160_I2C(self.i2c)
             self.hardware['IMU'] = True
         except Exception as e:
-            print('[ERROR]',e)
+            print('[ERROR]', e)
 
         # Initialize radio(s)
         try:
             self.radio1 = adafruit_rfm9x.RFM9x(self.spi, self._rf_cs1, self._rf_rst1, 433.0)
             self.hardware['Radio1'] = True
         except Exception as e:
-            print('[ERROR][RADIO 1]',e)
+            print('[ERROR][RADIO 1]', e)
         try:
             self.radio2 = adafruit_rfm9x.RFM9x(self.spi, self._rf_cs2, self._rf_rst2, 433.0)
             self.hardware['Radio2'] = True
         except Exception as e:
-            print('[ERROR][RADIO 2]',e)
+            print('[ERROR][RADIO 2]', e)
 
         # Initialize GPS
         # try:
@@ -227,14 +227,14 @@ class Satellite:
             return False
         try:
             name = 'DATA_000'
-            files = []
+
             for i in range(0,50):
                 _filename = name[:-2]+str(int(i/10))+str(int(i%10))+'.txt'
                 if _filename not in os.listdir('/sd/'):
-                    with open('/sd/'+_filename, "a") as f:
+                    with open('/sd/'+_filename, "a"):
                         time.sleep(0.01)
                     self.filename = '/sd/'+_filename
-                    print('filename is:',self.filename)
+                    print('filename is:', self.filename)
                     return True
         except Exception as e:
             print('[ERROR] Unique File:', e)
@@ -260,7 +260,7 @@ class Satellite:
             return False
 
     # this deployment function is a placeholder
-    def deploy(self,burnA=False,dutycycle=0,freq=5000,duration=1):
+    def deploy(self, burnA=False, dutycycle=0, freq=5000, duration=1):
         print('BURNING with duty cycle of:',dutycycle)
         # if not self._deployA:
         burn = pulseio.PWMOut(board.PA22, frequency=freq, duty_cycle=0)


### PR DESCRIPTION
Found unused imports and variables.  Removed trailing whitespace.  Removed invalid `bad-whitespace` option.